### PR TITLE
yarn add instead of yarn install

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ npm install -g react-vr-cli
 Or
 
 ```
-yarn global install react-vr-cli
+yarn global add react-vr-cli
 ```
 
 You'll only need to install this CLI once. It will alert you when it's out of date, and provide instruction on how to update it.


### PR DESCRIPTION
## Motivation (required)

Running the command on the readme results in the following:
```
$ yarn global install react-vr-cli
yarn global v0.21.3
error Invalid subcommand. Try "add, bin, ls, remove, upgrade"
info Visit https://yarnpkg.com/en/docs/cli/global for documentation about this command.
```
I changed the readme to not have yarn result in an error.
## Test Plan (required)
I ran the command I changed in the readme. (I did update yarn after this).
```
$ yarn global add react-vr-cli
yarn global v0.21.3
[1/4] 🔍  Resolving packages...
[2/4] 🚚  Fetching packages...
[3/4] 🔗  Linking dependencies...
[4/4] 📃  Building fresh packages...
warning Your current version of Yarn is out of date. The latest version is "0.23.2" while you're on "0.21.3".
info To upgrade, run the following command:
$ brew upgrade yarn
success Installed "react-vr-cli@0.3.0" with binaries:
      - react-vr
✨  Done in 5.29s.
```