### PR TITLE
remove `private` key from `package.json`

### DIFF
--- a/ReactVR/package.json
+++ b/ReactVR/package.json
@@ -1,5 +1,4 @@
 {
-  "private": true,
   "name": "react-vr-web",
   "version": "1.0.0",
   "description": "A framework for building VR applications with React",


### PR DESCRIPTION
I assume since the [package](https://www.npmjs.com/package/react-vr-web) is published on npm now, this is safe to change.
