### PR TITLE
Missing slash (/) in local server url added in package.json generator console.log

### DIFF
--- a/react-vr-cli/generators/package.json.generator.js
+++ b/react-vr-cli/generators/package.json.generator.js
@@ -16,7 +16,7 @@ module.exports = config => ({
   "version": "0.0.1",
   "private": true,
   "scripts": {
-    "start": "node -e \\"console.log('open browser at http:/localhost:8081/vr/\\\\n\\\\n');\\" && node node_modules/react-native/local-cli/cli.js start",
+    "start": "node -e \\"console.log('open browser at http://localhost:8081/vr/\\\\n\\\\n');\\" && node node_modules/react-native/local-cli/cli.js start",
     "bundle": "node node_modules/react-vr/scripts/bundle.js",
     "open": "node -e \\"require('xopen')('http://localhost:8081/vr/')\\"",
     "devtools": "react-devtools",


### PR DESCRIPTION

## Motivation (required)

I did run the app and in console saw saying - 
```
open browser at http:/localhost:8081/vr/
```
Immediately I saw there is a slash (/) missing and decided to add that. Easy fix and way to get a chance to proudly say I did contribute to React. 😄 


## Test Plan (required)

Running the app will show that its showing the correct url format.

```
open browser at http://localhost:8081/vr/
```