### PR TITLE
Typo fix in CylindricalPanel documentation

### DIFF
--- a/Libraries/VRLayers/CylindricalPanel.js
+++ b/Libraries/VRLayers/CylindricalPanel.js
@@ -36,7 +36,7 @@ const invariant = require('invariant');
  *     radius: distanceFromTheViewer
  *   }}>
  *   ... Child components ...
- * </CylindrialPanel>
+ * </CylindricalPanel>
  * ```
  *
  * The width and height of the cylinder must be specified and the width also correspond to how much


### PR DESCRIPTION
Fix a typo in the CylindricalPanel documentation. The closing `<CylindricalPanel`> tag was misspelled.