### PR TITLE
Fixed a typo in Input.md docs file

### DIFF
--- a/docs/Input.md
+++ b/docs/Input.md
@@ -141,7 +141,7 @@ are passed as the last argument when the `VRInstance` is constructed.
 
 const vr = new VRInstance(bundle, 'YourProject', parent, {
   // Custom initialization options go here
-  cusorVisibility: 'visible',
+  cursorVisibility: 'visible',
 
   ...options,
 });


### PR DESCRIPTION
## Motivation (required)

There was a typo in the documentation, it's gone now. All is well.

## Test Plan (required)

Erm... all test pass, so there's that.