### PR TITLE
Removed unused ColorPropType imports from Libraries

### DIFF
--- a/Libraries/Lights/AmbientLight.js
+++ b/Libraries/Lights/AmbientLight.js
@@ -10,7 +10,6 @@
  */
 'use strict';
 
-const ColorPropType = require('ColorPropType');
 const NativeMethodsMixin = require('NativeMethodsMixin');
 const PropTypes = require('react/lib/ReactPropTypes');
 const React = require('React');

--- a/Libraries/Lights/DirectionalLight.js
+++ b/Libraries/Lights/DirectionalLight.js
@@ -10,7 +10,6 @@
  */
 'use strict';
 
-const ColorPropType = require('ColorPropType');
 const NativeMethodsMixin = require('NativeMethodsMixin');
 const PropTypes = require('react/lib/ReactPropTypes');
 const React = require('React');

--- a/Libraries/Lights/PointLight.js
+++ b/Libraries/Lights/PointLight.js
@@ -10,7 +10,6 @@
  */
 'use strict';
 
-const ColorPropType = require('ColorPropType');
 const NativeMethodsMixin = require('NativeMethodsMixin');
 const PropTypes = require('react/lib/ReactPropTypes');
 const React = require('React');

--- a/Libraries/Lights/SpotLight.js
+++ b/Libraries/Lights/SpotLight.js
@@ -10,7 +10,6 @@
  */
 'use strict';
 
-const ColorPropType = require('ColorPropType');
 const NativeMethodsMixin = require('NativeMethodsMixin');
 const PropTypes = require('react/lib/ReactPropTypes');
 const React = require('React');

--- a/Libraries/Mesh/Box.js
+++ b/Libraries/Mesh/Box.js
@@ -10,7 +10,6 @@
  */
 'use strict';
 
-const ColorPropType = require('ColorPropType');
 const NativeMethodsMixin = require('NativeMethodsMixin');
 const PropTypes = require('react/lib/ReactPropTypes');
 const React = require('React');

--- a/Libraries/Mesh/Cylinder.js
+++ b/Libraries/Mesh/Cylinder.js
@@ -10,7 +10,6 @@
  */
 'use strict';
 
-const ColorPropType = require('ColorPropType');
 const NativeMethodsMixin = require('NativeMethodsMixin');
 const PropTypes = require('react/lib/ReactPropTypes');
 const React = require('React');

--- a/Libraries/Mesh/Model.js
+++ b/Libraries/Mesh/Model.js
@@ -10,7 +10,6 @@
  */
 'use strict';
 
-const ColorPropType = require('ColorPropType');
 const NativeMethodsMixin = require('NativeMethodsMixin');
 const PropTypes = require('react/lib/ReactPropTypes');
 const React = require('React');

--- a/Libraries/Mesh/Plane.js
+++ b/Libraries/Mesh/Plane.js
@@ -10,7 +10,6 @@
  */
 'use strict';
 
-const ColorPropType = require('ColorPropType');
 const NativeMethodsMixin = require('NativeMethodsMixin');
 const PropTypes = require('react/lib/ReactPropTypes');
 const React = require('React');

--- a/Libraries/Mesh/Sphere.js
+++ b/Libraries/Mesh/Sphere.js
@@ -10,7 +10,6 @@
  */
 'use strict';
 
-const ColorPropType = require('ColorPropType');
 const NativeMethodsMixin = require('NativeMethodsMixin');
 const PropTypes = require('react/lib/ReactPropTypes');
 const React = require('React');

--- a/Libraries/Pano/Pano.js
+++ b/Libraries/Pano/Pano.js
@@ -10,7 +10,6 @@
  */
 'use strict';
 
-const ColorPropType = require('ColorPropType');
 const NativeMethodsMixin = require('NativeMethodsMixin');
 const PropTypes = require('react/lib/ReactPropTypes');
 const React = require('React');

--- a/Libraries/Video/Video.js
+++ b/Libraries/Video/Video.js
@@ -10,7 +10,6 @@
  */
 'use strict';
 
-const ColorPropType = require('ColorPropType');
 const NativeMethodsMixin = require('NativeMethodsMixin');
 const PropTypes = require('react/lib/ReactPropTypes');
 const React = require('React');

--- a/Libraries/VideoPano/VideoPano.js
+++ b/Libraries/VideoPano/VideoPano.js
@@ -10,7 +10,6 @@
  */
 'use strict';
 
-const ColorPropType = require('ColorPropType');
 const NativeMethodsMixin = require('NativeMethodsMixin');
 const PropTypes = require('react/lib/ReactPropTypes');
 const React = require('React');


### PR DESCRIPTION
## Motivation (required)

I've run `npm run lint` and aside from `prettier` errors (I don't know if those are meant to be fixed, I assume that linting is not a part of CI at this stage? I can fix those linting issues in another PR 👍 ) I've noticed a bunch of unused import statements. To be exact - `ColorPropType` was imported in a bunch of `Libraries` without being used at all. This PR addresses that.

## Test Plan (required)

`npm run test` returns no errors
