### PR TITLE
Updated repo and issues path in package.json

### DIFF
--- a/ReactVR/package.json
+++ b/ReactVR/package.json
@@ -6,9 +6,9 @@
   "license": "BSD-3-Clause",
   "repository": {
     "type": "git",
-    "url": "https://github.com/facebookincubator/react-vr.git"
+    "url": "https://github.com/facebook/react-vr.git"
   },
-  "bugs": "https://github.com/facebookincubator/react-vr/issues",
+  "bugs": "https://github.com/facebook/react-vr/issues",
   "main": "ReactVR.js",
   "files": [
     "js",

--- a/package.json
+++ b/package.json
@@ -6,9 +6,9 @@
   "license": "BSD-3-Clause",
   "repository": {
     "type": "git",
-    "url": "https://github.com/facebookincubator/react-vr.git"
+    "url": "https://github.com/facebook/react-vr.git"
   },
-  "bugs": "https://github.com/facebookincubator/react-vr/issues",
+  "bugs": "https://github.com/facebook/react-vr/issues",
   "main": "Libraries/react-vr.js",
   "files": [
     "jest/setup.js",

--- a/react-vr-cli/package.json
+++ b/react-vr-cli/package.json
@@ -8,9 +8,9 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/facebookincubator/react-vr.git"
+    "url": "https://github.com/facebook/react-vr.git"
   },
-  "bugs": "https://github.com/facebookincubator/react-vr/issues",
+  "bugs": "https://github.com/facebook/react-vr/issues",
   "files": [
     "static_assets/",
     "src/",


### PR DESCRIPTION
## Motivation (required)

`package.json` was still pointing to the old `facebook-incubator` repo, this PR addresses that.

## Test Plan (required)
N/A
