### PR TITLE
Added support for --help command in react-vr-cli

### DIFF
--- a/react-vr-cli/index.js
+++ b/react-vr-cli/index.js
@@ -57,7 +57,7 @@ getLatestVersion().then(version => {
       console.log(chalk.green('  npm update -g react-vr-cli'));
     }
   }
-  if (args.length === 0) {
+  if (args.length === 0 || args[0] === '--help') {
     printUsageAndExit();
   }
   if (args[0] === 'init') {


### PR DESCRIPTION
## Motivation (required)

Currently running `react-vr --help` results in a following output:
```
MacBook-Pro-3:react-vr-cli TomaszLakomy$ react-vr --help
Unsupported command: --help
React VR Command Line Interface
Version 0.1.3

Usage:
  react-vr init [project name]	Create a new React VR application with the specified name
```

This `Unsupported command: --help` can be confusing to a developer who is just starting with React VR. I personally always try to execute `--help` command on any cli I'm not familiar with (that's why I found out that `--help` is not supported in the first place). 

This PR ensured that running `react-vr` and `react-vr --help` commands will have the same output so it won't be confusing.

## Test Plan (required)

Fetch this branch and run `node react-vr-cli/index.js --help` to see that the `Unsupported command: --help` is no longer displayed
