### PR TITLE
Fix E2E tests on Circle CI

### DIFF
--- a/EndToEnd/testapp/rn-cli.config.js
+++ b/EndToEnd/testapp/rn-cli.config.js
@@ -18,7 +18,7 @@ var config = {
 
   getBlacklistRE() {
     return blacklist([
-      /.*[/\\]ReactVR[/\\]OVRUI[/\\]package\.json/,
+      /.*[/\\]OVRUI[/\\]package\.json/,
     ]);
   },
 

--- a/circle.yml
+++ b/circle.yml
@@ -24,7 +24,7 @@ test:
 
 deployment:
   website:
-    branch: master
+    tag: /release-.*/
     commands:
       # generate docs website
       - git config --global user.email "reactjs-bot@users.noreply.github.com"


### PR DESCRIPTION
When running on Circle, the directory is called `react-vr`, so let's just match the top of the file path. This should also stop the failing deploy attempts each time a commit is merged into master.