### PR TITLE
Fix chromium bug (frozen chaperone)

### DIFF
--- a/OVRUI/src/Player/Player.js
+++ b/OVRUI/src/Player/Player.js
@@ -184,10 +184,10 @@ export default class Player {
 
     // Set up the Three.js basics: renderer, camera, controls
     const antialias = options.hasOwnProperty('antialias') ? options.antialias : true;
-    const canvasAlpha = options.hasOwnProperty('canvasAlpha') ? options.canvasAlpha : true;
+    const alpha = options.hasOwnProperty('canvasAlpha') ? options.canvasAlpha : true;
     const renderer = new THREE.WebGLRenderer({
       antialias: antialias,
-      alpha: canvasAlpha,
+      alpha: alpha,
     });
     renderer.setPixelRatio(pixelRatio);
     renderer.setSize(width, height);

--- a/OVRUI/src/Player/Player.js
+++ b/OVRUI/src/Player/Player.js
@@ -184,8 +184,10 @@ export default class Player {
 
     // Set up the Three.js basics: renderer, camera, controls
     const antialias = options.hasOwnProperty('antialias') ? options.antialias : true;
+    const alpha = options.hasOwnProperty('alpha') ? options.alpha : true;
     const renderer = new THREE.WebGLRenderer({
       antialias: antialias,
+      alpha: alpha,
     });
     renderer.setPixelRatio(pixelRatio);
     renderer.setSize(width, height);

--- a/OVRUI/src/Player/Player.js
+++ b/OVRUI/src/Player/Player.js
@@ -184,10 +184,10 @@ export default class Player {
 
     // Set up the Three.js basics: renderer, camera, controls
     const antialias = options.hasOwnProperty('antialias') ? options.antialias : true;
-    const alpha = options.hasOwnProperty('alpha') ? options.alpha : true;
+    const canvasAlpha = options.hasOwnProperty('canvasAlpha') ? options.canvasAlpha : true;
     const renderer = new THREE.WebGLRenderer({
       antialias: antialias,
-      alpha: alpha,
+      alpha: canvasAlpha,
     });
     renderer.setPixelRatio(pixelRatio);
     renderer.setSize(width, height);


### PR DESCRIPTION
## Motivation

Same issue as [this](https://github.com/toji/chrome-webvr-issues/issues/64#issuecomment-251826187). Basically chaperone gets frozen and nothing else gets rendered. Also got this warning message in the console: `GL ERROR :GL_INVALID_OPERATION : glFramebufferTexture2D`.

The same issue was solved by adding `alpha: true` when constructing the `WebGLRenderer`.

## Test Plan

I've only got a Vive so needs to be tested on other non-openVR platforms.