### PR TITLE
WebSocketModule (re-submit): fix secure websocket creation when protocols is null 

### DIFF
--- a/ReactVR/js/Modules/WebSocketModule.js
+++ b/ReactVR/js/Modules/WebSocketModule.js
@@ -42,7 +42,7 @@ export default class WebSocketModule extends Module {
    * @param socketId - ID used to represent this connection in React
    */
   connect(url: string, protocols: string | Array<string>, options: any, socketId: number) {
-    const socket = new WebSocket(url, protocols);
+    const socket = protocols ? new WebSocket(url, protocols) : new WebSocket(url);
     socket.binaryType = 'arraybuffer';
     this._sockets[String(socketId)] = socket;
 


### PR DESCRIPTION
- [x] Explain the **motivation** for making this change.
- [x] Provide a **test plan** demonstrating that the code is solid.

## Motivation (required)

This PR fixes https://github.com/facebook/react-vr/issues/118. As Firebase uses `wss`, when combining firebase and react-vr shows that secure WebSockets are create with a `null` protocol parameter (https://developer.mozilla.org/en-US/docs/Web/API/WebSocket). As a consequence, the header `Sec-WebSocket-Protocol` is set to `null` which is not handled by firebase and make it responds with a 500 error code. 

## Test Plan (required)

With a sample react-vr app, (https://github.com/alexduros/react-vr-app), I was able to test it with fixed `WebSocketModule` and the connexion with firebase is then ok.
