### PR TITLE
Add 'transparent' prop

### DIFF
--- a/Libraries/Mesh/Box.js
+++ b/Libraries/Mesh/Box.js
@@ -59,6 +59,11 @@ const Box = React.createClass({
     lit: PropTypes.bool,
 
     /**
+    * The transparent property specifies if the Model renders with any transparency.
+    */
+    transparent: PropTypes.bool,
+
+    /**
      * `texture` is a string specifying the url of the texture to be used for the Model, this will be
      * an http address
      */

--- a/Libraries/Mesh/Cylinder.js
+++ b/Libraries/Mesh/Cylinder.js
@@ -70,6 +70,11 @@ const Cylinder = React.createClass({
     lit: PropTypes.bool,
 
     /**
+    * The transparent property specifies if the Model renders with any transparency.
+    */
+    transparent: PropTypes.bool,
+
+    /**
      * `texture` is a string specifying the url of the texture to be used for the Model, this will be
      * an http address
      */

--- a/Libraries/Mesh/Model.js
+++ b/Libraries/Mesh/Model.js
@@ -83,6 +83,11 @@ const Model = React.createClass({
     lit: PropTypes.bool,
 
     /**
+    * The transparent property specifies if the Model renders with any transparency.
+    */
+    transparent: PropTypes.bool,
+
+    /**
      * `obj` is a string representing the resource identifier for the Model, this will be
      * an http address
      * The source properties will enable future expansion to support additional formats

--- a/Libraries/Mesh/Plane.js
+++ b/Libraries/Mesh/Plane.js
@@ -58,6 +58,11 @@ const Plane = React.createClass({
     lit: PropTypes.bool,
 
     /**
+    * The transparent property specifies if the Model renders with any transparency.
+    */
+    transparent: PropTypes.bool,
+
+    /**
      * `texture` is a string specifying the url of the texture to be used for the Plane face,
      * this will be an http address
      */

--- a/Libraries/Mesh/Sphere.js
+++ b/Libraries/Mesh/Sphere.js
@@ -60,6 +60,11 @@ const Sphere = React.createClass({
     lit: PropTypes.bool,
 
     /**
+    * The transparent property specifies if the Model renders with any transparency.
+    */
+    transparent: PropTypes.bool,
+
+    /**
      * `texture` is a string specifying the url of the texture to be used for the sphere,
      * this will be an http address
      * the image is wrap around the sphere

--- a/ReactVR/js/Views/BaseMesh.js
+++ b/ReactVR/js/Views/BaseMesh.js
@@ -53,6 +53,7 @@ function getTextureForURL(url) {
 export default class RCTBaseMesh extends RCTBaseView {
   _color: ?number;
   _lit: boolean;
+  _transparent: boolean;
   _wireframe: boolean;
   _textureURL: null | string;
   _texture: null | Texture;
@@ -65,6 +66,7 @@ export default class RCTBaseMesh extends RCTBaseView {
     super();
 
     this._lit = false;
+    this._transparent = false;
     this._wireframe = false;
     this._textureURL = null;
     this._texture = null; // Cache for THREE Texture
@@ -83,15 +85,19 @@ export default class RCTBaseMesh extends RCTBaseView {
           if (value === null) {
             this._litMaterial.opacity = 1;
             this._unlitMaterial.opacity = 1;
-            this._litMaterial.transparent = false;
-            this._unlitMaterial.transparent = false;
           } else {
             this._litMaterial.opacity = value;
             this._unlitMaterial.opacity = value;
-            this._litMaterial.transparent = value < 1;
-            this._unlitMaterial.transparent = value < 1;
           }
         },
+      }: Object)
+    );
+
+    Object.defineProperty(
+      this.props,
+      'transparent',
+      ({
+        set: this._setTransparent.bind(this),
       }: Object)
     );
 
@@ -175,6 +181,12 @@ export default class RCTBaseMesh extends RCTBaseView {
     );
   }
 
+  _setTransparent(flag: boolean) {
+    this._transparent = flag;
+    this._litMaterial.transparent = flag;
+    this._unlitMaterial.transparent = flag;
+  }
+
   _setLit(flag: boolean) {
     this._lit = flag;
     const mat = flag ? this._litMaterial : this._unlitMaterial;
@@ -222,6 +234,7 @@ export default class RCTBaseMesh extends RCTBaseView {
       // register the properties sent from react to runtime
       NativeProps: {
         lit: 'boolean',
+        transparent: 'boolean',
         texture: 'object',
         wireframe: 'boolean',
       },


### PR DESCRIPTION
## Motivation (required)

To resolve #175 where cannot independently set opacity & transparent property. There are use cases that require breaking apart i.e. say a Box with a png texture (with alpha that don't want to be transparent) that want to opacity fade whole object in and out; or a textured plane that want to fade to its style color, not make transparent to background scene.

## Test Plan (required)

TBD. Looking for feedback on solution approach first.

