### PR TITLE
Support scripts/build-packages.js for windows platform

### DIFF
--- a/scripts/build-packages.js
+++ b/scripts/build-packages.js
@@ -19,6 +19,7 @@ function prepare() {
     const npm = child_process.spawn('npm', ['run', 'build'], {
       stdio: 'inherit',
       cwd: PACKAGES.ovrui,
+      shell: true      
     });
     npm.on('close', code => {
       if (code !== 0) {
@@ -44,7 +45,7 @@ function buildPackage(name, dir) {
   }).then(json => {
     const version = require(json).version;
     return new Promise((resolve, reject) => {
-      const npm = child_process.spawn('npm', ['pack'], {stdio: 'inherit', cwd: dir});
+      const npm = child_process.spawn('npm', ['pack'], {stdio: 'inherit', cwd: dir, shell: true});
       npm.on('close', code => {
         if (code !== 0) {
           reject(code);


### PR DESCRIPTION
## Motivation (required)
version:8681fc1b80999185fb0dafa43350006c0f417ac9
Run "node scripts/build-packages.js" throw error in windows 7:
![Error_snapshots](http://i.imgur.com/0auRiSo.png)

## Test Plan (required)

![test_snapshots](http://i.imgur.com/ktfwXBK.png)