### PR TITLE
#203 mute error output on yarn packager check (Windows)

### DIFF
--- a/react-vr-cli/src/getPackager.js
+++ b/react-vr-cli/src/getPackager.js
@@ -17,7 +17,7 @@ function getPackager() {
   }
   try {
     child_process.execSync(
-      /^win/.test(process.platform) ? 'yarn --version' : 'yarn --version 2>/dev/null'
+      /^win/.test(process.platform) ? 'yarn --version 2> NUL' : 'yarn --version 2>/dev/null'
     );
     packager = 'yarn';
   } catch (e) {


### PR DESCRIPTION
Thanks for submitting a PR! Please read these instructions carefully:

- [x] Explain the **motivation** for making this change.
- [x] Provide a **test plan** demonstrating that the code is solid.
- [x] Match the **code formatting** of the rest of the codebase.

## Motivation (required)

Fixes #203 wherein the check for `yarn` outputs extraneous error messaging. This mutes the error output on Windows.

## Test Plan (required)

#BrokenWindows here, cli doesn't have tests and I don't want to presume to design a testing setup for it, considering the JS side wouldn't be very knowledgeable about this change anyhow. 

I hope the following demonstrates the fix:

![image](https://cloud.githubusercontent.com/assets/4138357/26280295/88364a20-3d92-11e7-873e-2301dd5a3e08.png)


## Next Steps

Sign the [CLA][2], if you haven't already.

Small pull requests are much easier to review and more likely to get merged. Make sure the PR does only one thing, otherwise please split it.

Make sure all **tests pass** on [Circle CI][3]. PRs that break tests are unlikely to be merged.

For more info, see the ["Pull Requests"][4] section of our "Contributing" guidelines.

*** Of note, lint is failing on non-cli stuff. I can pick those up separately.

[1]: https://medium.com/@martinkonicek/what-is-a-test-plan-8bfc840ec171#.y9lcuqqi9
[2]: https://code.facebook.com/cla
[3]: http://circleci.com/gh/facebook/react-native
[4]: https://github.com/facebook/react-vr/blob/master/CONTRIBUTING.md#pull-requests
