### PR TITLE
Copy body data for PATCH when sending request.

### DIFF
--- a/ReactVR/js/Modules/Networking.js
+++ b/ReactVR/js/Modules/Networking.js
@@ -69,8 +69,8 @@ export default class Networking extends Module {
       headers: headers,
     };
 
-    // copy over the body data for POST in the correct form
-    if (method === 'POST' && data) {
+    // copy over the body data for POST/PATCH in the correct form
+    if ((method === 'POST' || method === 'PATCH') && data) {
       if (data.string) {
         options.body = data.string;
       } else if (data.formData) {


### PR DESCRIPTION
## Motivation

Solves the issue outlined in #218

When `PATCH`ing, the body of the request is not sent.

## Test Plan

Inside of a `componentDidMount` or some event handler in your react-vr codebase, add the following code:

```js
    const payload = {
      data: {
        id: 'de0db600-9a0a-416d-b42b-a19d31aad039',
        attributes: {
          field_rotation: '-96',
          field_rotation_x: '10',
        },
      },
    };

    fetch(`http://httpbin.org/patch`, {
      method: 'patch',
      body: JSON.stringify(payload),
      headers: {
        "Content-Type": "application/vnd.api+json"
      }
    })
    .then(res => res.json())
    .then(console.log)
```
In the console, you should see

<img width="961" alt="react-vr-body-pr-success" src="https://cloud.githubusercontent.com/assets/1127238/26806183/6c97446c-4a04-11e7-9cdb-cba70b0b8def.png">

Thank you for all of your hard work on this project. ❤️ 😄 