### PR TITLE
Fix OVRUI export path.

### DIFF
--- a/OVRUI/index.js
+++ b/OVRUI/index.js
@@ -11,4 +11,4 @@
  * Entry point for the OVRUI npm package
  */
 
-module.exports = require('./lib/OVRUI');
+module.exports = require('./src/OVRUI');


### PR DESCRIPTION
## Motivation

`master` is currently unusable due to a path issue in the OVRUI export. This change get's things working again 😀 

## Test Plan
* clone master
* `yarn link react-vr` into an existing project
* `cd` to existing-project
* `yarn start`
* See `Uncaught ReferenceError: ReactVR is not defined` in console.
* Apply this change in `OVRUI/index.js` of your linked `react-vr`
* `yarn start` in project
* Things work 🎉 
