### PR TITLE
test for string type before parsing

### DIFF
--- a/ReactVR/js/RNBridge.js
+++ b/ReactVR/js/RNBridge.js
@@ -15,6 +15,9 @@
 var Status = undefined;
 
 onmessage = function(e) {
+  if (typeof e.data !== 'string') {
+    return;
+  }
   var msg = JSON.parse(e.data);
   if (!msg || !msg.cmd) {
     return;

--- a/ReactVR/js/createRootView.js
+++ b/ReactVR/js/createRootView.js
@@ -41,6 +41,9 @@ let BRIDGE_CODE = `
 var Status = undefined;
 
 onmessage = function(e) {
+  if (typeof e.data !== 'string') {
+    return;
+  }
   var msg = JSON.parse(e.data);
   if (!msg || !msg.cmd) {
     return;


### PR DESCRIPTION
## Motivation
Currently sending webworker messages as objects will throw an error because the react vr worker doesn't ignore messages which are objects.

## Test Plan

```
react-vr init workerbug && cd workerbug
npm i
# add an additional listener for custom communication
echo "window.addEventListener('message', (e) => console.log('Message:', e.data))" >> index.vr.js;
# post to the worker from client.js
sed -i 's/return/vr.rootView.context.worker.postMessage({ test: "hi" });\n  return/' vr/client.js 
npm start
```
Visit http://localhost:8081/vr

Error:
```
VM34:1 Uncaught SyntaxError: Unexpected token o in JSON at position 1
    at JSON.parse (<anonymous>)
    at onmessage (blob:http://localhost:8081/67209ef0-1523-4a76-9b64-9127f1e34677:5)
```

The additional listener does receive the message, but the react-vr listener will always throw an error first.