### PR TITLE
Fixing #279 adding ability to use absolute URLs for bundled files.

### DIFF
--- a/ReactVR/ReactVR.js
+++ b/ReactVR/ReactVR.js
@@ -11,7 +11,7 @@
  * @providesModule ReactVRApp
  */
 
-import bundleFromRoot from './js/bundleFromRoot';
+import bundleFromLocation from './js/bundleFromLocation';
 import createRootView from './js/createRootView';
 import Module from './js/Modules/Module';
 import RCTBaseView from './js/Views/BaseView';
@@ -20,7 +20,7 @@ import {BasicVideoPlayer, addCustomizedVideoPlayer, getSupportedFormats} from '.
 
 import {ReactNativeContext} from './js/ReactNativeContext';
 
-export {bundleFromRoot};
+export {bundleFromLocation};
 export {createRootView};
 export {Module};
 export {RCTBaseView};

--- a/ReactVR/js/VRInstance.js
+++ b/ReactVR/js/VRInstance.js
@@ -11,7 +11,7 @@
 
 import {Scene} from 'three';
 import {Player, GuiSys} from 'ovrui';
-import bundleFromRoot from './bundleFromRoot';
+import bundleFromLocation from './bundleFromLocation';
 import createRootView from './createRootView';
 
 import type {RootView} from './createRootView';
@@ -139,7 +139,7 @@ export default class VRInstance {
     this.rootView = createRootView(this.guiSys, root, {
       // Name of the mounted root module, from AppRegistry
       assetRoot: assetRoot,
-      bundle: bundleFromRoot(bundle),
+      bundle: bundleFromLocation(bundle),
       customViews: options.customViews,
       enableHotReload: options.enableHotReload,
       initialProps: options.initialProps,

--- a/ReactVR/js/bundleFromLocation.js
+++ b/ReactVR/js/bundleFromLocation.js
@@ -15,10 +15,11 @@
  */
 export default function bundleFromLocation(root: string): string {
   let path = location.pathname;
-  let isAbsoluteURL = /http:\/\/|https:\/\//.test(root);
-  if(isAbsoluteURL) {
-    return root;
-  } else {
+  try {
+    let absoluteURL = new URL(root);
+    return absoluteURL.toString();
+  } catch (error) {
+    //location is not an absolute URL, generate one from the root
     if (!path.endsWith('/')) {
       // Trim filename
       path = path.substr(0, path.lastIndexOf('/'));

--- a/ReactVR/js/bundleFromLocation.js
+++ b/ReactVR/js/bundleFromLocation.js
@@ -13,13 +13,18 @@
  * Turns a relative path into a full path based upon the current location.
  * Full paths are required for Web Workers loading external scripts.
  */
-export default function bundleFromRoot(root: string): string {
+export default function bundleFromLocation(root: string): string {
   let path = location.pathname;
-  if (!path.endsWith('/')) {
-    // Trim filename
-    path = path.substr(0, path.lastIndexOf('/'));
+  let isAbsoluteURL = /http:\/\/|https:\/\//.test(root);
+  if(isAbsoluteURL) {
+    return root;
   } else {
-    path = path.substr(0, path.length - 1);
+    if (!path.endsWith('/')) {
+      // Trim filename
+      path = path.substr(0, path.lastIndexOf('/'));
+    } else {
+      path = path.substr(0, path.length - 1);
+    }
+    return location.protocol + '//' + location.host + path + '/' + root;
   }
-  return location.protocol + '//' + location.host + path + '/' + root;
 }


### PR DESCRIPTION
## Motivation (required)

Referencing bundled packages from an absolute URL if it matches  a pattern, otherwise reference from the app root rather than always referencing from app root.

###Test Plan

All tests passed on circleCI

