### PR TITLE
Limit bundler workers on Circle CI

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -20,7 +20,7 @@ dependencies:
 test:
   override:
     - npm run flow -- check
-    - npm run test
+    - REACT_NATIVE_MAX_WORKERS=1 npm run test
     # test website generation
     - cd website && node ./server/generate.js
 


### PR DESCRIPTION
Avoid exceeding the container's hard memory limitation. RN 0.47 will allow us to move this to a command-line arg.
