### PR TITLE
Update README.md of pairs

### DIFF
--- a/Examples/Pairs/README.md
+++ b/Examples/Pairs/README.md
@@ -9,11 +9,11 @@ To play pairs on your local host:
 
 1. Run ```npm run-script relay``` to start a wsrelay websocket relay server.
 2. Run ```npm start``` in a second shell to serve the ReactVR application.
-3. Open ```http://localhost:8081/vr/``` in multiple web browsers to play pairs.
+3. Open ```http://localhost:8081/Examples/Pairs/vr/``` in multiple web browsers to play pairs.
 
 To play pairs over the internet:
 
 1. Run ```npm run-script relay``` to start a wsrelay websocket relay server.
 2. Run ```ngrok http 4000``` to create an [ngrok](https://ngrok.com/) tunnel to your relay server.
 3. Run ```npm start``` in a shell on each machine to serve the ReactVR application.
-4. Open ```http://localhost:8081/vr/#ws://...ngrok.io``` in a web browser on each machine (set the hash fragment to the forwarding address from ngrok) to play pairs.
+4. Open ```http://localhost:8081/Examples/Pairs/vr/#ws://...ngrok.io``` in a web browser on each machine (set the hash fragment to the forwarding address from ngrok) to play pairs.


### PR DESCRIPTION
The url to open pairs was incorrect. It should be `http://localhost:8081/Examples/Pairs/vr/`, not `http://localhost:8081/vr/`.

Thanks for submitting a PR! Please read these instructions carefully:

- [ ] Explain the **motivation** for making this change.
- [ ] Provide a **test plan** demonstrating that the code is solid.
- [ ] Match the **code formatting** of the rest of the codebase.

## Motivation (required)

Puts the correct URL in README.

## Test Plan (required)

Follow the steps to open pairs locally and using `ngrok`.