### PR TITLE
Changed link for the React Native Packager

### DIFF
--- a/docs/ReactVROverview.md
+++ b/docs/ReactVROverview.md
@@ -124,7 +124,7 @@ index.vr.bundle
 
 The resultant index.vr.bundle file contains JavaScript code that can be directly fetched and executed by an HTML **`script`** tag.
 
-Due to the scope of the project, we only discuss our usage. For more general information on the Packager, see [React Native Packager](https://github.com/facebook/react-native/blob/master/packager/README.md).
+Due to the scope of the project, we only discuss our usage. For more general information on the Packager, see [React Native Packager](https://github.com/facebook/metro-bundler).
 
 #### Networking
 


### PR DESCRIPTION
The React Native packager no longer exists at the previous location linked in ReactVROverview.md. The packager, now named Metro Bundler, is now a stand-alone repo. See https://github.com/facebook/react-native/issues/13976.

## Motivation (required)
The link for the React Native packager directs to a 404 page not found. The link has been updated to reflect the new home for the packager i.e. the Metro Bundler, which is it's [GitHub repo](https://github.com/facebook/react-native/issues/13976).

## Test Plan (required)

Click the previous link ([here](https://github.com/facebook/react-native/blob/master/packager/README.md)) and see that it 404s. :)