### PR TITLE
Replaced occurrences of CSSLayout with the new name Yoga

### DIFF
--- a/docs/LayoutAndStyle.md
+++ b/docs/LayoutAndStyle.md
@@ -10,7 +10,7 @@ previous: reactnative
 
 React VR makes use of a Flexbox style layout algorithm to automatically position components and their children.
 
-The library we use, [CSSLayout](https://github.com/facebook/css-layout), tries to follows the web implementation of flexbox as much as possible. CSSLayout does make changes to the default properties, and [these changes](http://jsfiddle.net/vjeux/y11txxv9/) can be forked to allow testing in a browser environment.
+The library we use, [Yoga](https://github.com/facebook/yoga), tries to follows the web implementation of flexbox as much as possible. Yoga does make changes to the default properties, and [these changes](http://jsfiddle.net/vjeux/y11txxv9/) can be forked to allow testing in a browser environment.
 
 #### Layout Sample
 


### PR DESCRIPTION
## Motivation

The Layout and Style doc refers to CSSLayout but this library has been rebranded to Yoga. This fix addresses that by changing those references including the link to the Yoga repo.

## Test Plan

For testing I ran the website locally and checked http://localhost:8079/react-vr/docs/layout-and-style.html

<img width="902" alt="screen shot 2017-08-08 at 1 31 19 pm" src="https://user-images.githubusercontent.com/691109/29094145-200d56ee-7c41-11e7-9e66-44ae0bc97223.png">

