### PR TITLE
Allows mouse clicks to be used for selection with Windows Mixed Reality Headsets in Edge

### DIFF
--- a/OVRUI/src/Player/Player.js
+++ b/OVRUI/src/Player/Player.js
@@ -186,6 +186,8 @@ export default class Player {
     (this: any).handleFullscreenChange = this.handleFullscreenChange.bind(this);
     (this: any).exitVR = this.exitVR.bind(this);
     (this: any).resetAngles = this.resetAngles.bind(this);
+    (this: any).handlePointerRestricted = this.handlePointerRestricted.bind(this);
+    (this: any).handlePointerUnrestricted = this.handlePointerUnrestricted.bind(this);
 
     this.isMobile = isMobile;
     this.allowCarmelDeeplink = !!options.allowCarmelDeeplink && isSamsung;
@@ -303,6 +305,8 @@ export default class Player {
     this.controls = new AppControls(this._camera, this.glRenderer.domElement, this.controlOptions);
     this.onEnterVR = options.onEnterVR;
     this.onExitVR = options.onExitVR;
+    window.addEventListener('vrdisplaypointerrestricted', this.handlePointerRestricted);
+    window.addEventListener('vrdisplaypointerunrestricted', this.handlePointerUnrestricted);
 
     // Create an Overlay, which places some interactive controls on top of
     // the rendering canvas
@@ -368,6 +372,28 @@ export default class Player {
 
     // Detect any VR displays, so that we can pick the proper rAF and render
     this.initializeDisplay();
+  }
+
+  /**
+   * Handles taking ponterlock in response to pointer input being restricted
+   */
+  handlePointerRestricted() {
+    var pointerLockElement = this.glRenderer.domElement;
+    if (pointerLockElement && pointerLockElement.requestPointerLock) {
+      pointerLockElement.requestPointerLock();
+    }
+  }
+
+  /**
+   * Handles releasing ponterlock in response to pointer input being unrestricted
+   */
+  handlePointerUnrestricted() {
+    var currentPointerLockElement = document.pointerLockElement;
+    var expectedPointerLockElement = this.glRenderer.domElement;
+    if (currentPointerLockElement && currentPointerLockElement === expectedPointerLockElement
+      && document.exitPointerLock) {
+      document.exitPointerLock();
+    }
   }
 
   /**

--- a/OVRUI/src/Player/Player.js
+++ b/OVRUI/src/Player/Player.js
@@ -305,8 +305,6 @@ export default class Player {
     this.controls = new AppControls(this._camera, this.glRenderer.domElement, this.controlOptions);
     this.onEnterVR = options.onEnterVR;
     this.onExitVR = options.onExitVR;
-    window.addEventListener('vrdisplaypointerrestricted', this.handlePointerRestricted);
-    window.addEventListener('vrdisplaypointerunrestricted', this.handlePointerUnrestricted);
 
     // Create an Overlay, which places some interactive controls on top of
     // the rendering canvas
@@ -369,6 +367,9 @@ export default class Player {
     // Listen for headsets that connect / disconnect after the page has loaded
     window.addEventListener('vrdisplayconnect', this.onDisplayConnect);
     window.addEventListener('vrdisplaydisconnect', this.onDisplayDisconnect);
+    // Listen for pointer becoming restricted / unrestricted
+    window.addEventListener('vrdisplaypointerrestricted', this.handlePointerRestricted);
+    window.addEventListener('vrdisplaypointerunrestricted', this.handlePointerUnrestricted);
 
     // Detect any VR displays, so that we can pick the proper rAF and render
     this.initializeDisplay();
@@ -378,8 +379,8 @@ export default class Player {
    * Handles taking ponterlock in response to pointer input being restricted
    */
   handlePointerRestricted() {
-    var pointerLockElement = this.glRenderer.domElement;
-    if (pointerLockElement && pointerLockElement.requestPointerLock) {
+    const pointerLockElement = this.glRenderer.domElement;
+    if (pointerLockElement && typeof(pointerLockElement.requestPointerLock) === 'function') {
       pointerLockElement.requestPointerLock();
     }
   }
@@ -388,10 +389,11 @@ export default class Player {
    * Handles releasing ponterlock in response to pointer input being unrestricted
    */
   handlePointerUnrestricted() {
-    var currentPointerLockElement = document.pointerLockElement;
-    var expectedPointerLockElement = this.glRenderer.domElement;
+    // $FlowFixMe
+    const currentPointerLockElement = document.pointerLockElement;
+    const expectedPointerLockElement = this.glRenderer.domElement;
     if (currentPointerLockElement && currentPointerLockElement === expectedPointerLockElement
-      && document.exitPointerLock) {
+      && typeof(document.exitPointerLock) === 'function') {
       document.exitPointerLock();
     }
   }


### PR DESCRIPTION
Adds support for Windows Mixed Reality mouse input by responding to pointer restriction events
When pointer is restricted, the only way to recieve mouse clicks is via pointerLock
Release pointerlock when not restricted to enable demo driver type scenarios

## Motivation (required)

Allows mouse clicks to be used for selection with Windows Mixed Reality Headsets in Edge

## Test Plan (required)

Load any React-based WebVR experience in Microsoft Edge, enter VR, and ensure mouse clicks function to select and click on 3D objects
Press Win+Y and ensure pointerlock is released and the mouse moves freely on the desktop
