### PR TITLE
Add 

### DIFF
--- a/ReactVR/js/Views/BaseMesh.js
+++ b/ReactVR/js/Views/BaseMesh.js
@@ -156,6 +156,7 @@ export default class RCTBaseMesh extends RCTBaseView {
     if (!url) {
       throw new Error('Invalid value for "texture" property: ' + JSON.stringify(value));
     }
+    const repeat = typeof value === 'object' ? value.repeat : null;
     this._loadingURL = url;
     const manager = this._rnctx.TextureManager;
     manager.addReference(url);
@@ -174,6 +175,11 @@ export default class RCTBaseMesh extends RCTBaseView {
           }
           this._texture = texture;
           this._texture.needsUpdate = true;
+          if (repeat && Array.isArray(repeat)) {
+            this._texture.wrapS = THREE.RepeatWrapping;
+            this._texture.wrapT = THREE.RepeatWrapping;
+            this._texture.repeat.set(...repeat);
+          }
           this._textureURL = url;
           // TODO: Consider providing props on BaseMesh to control these as well
           this._litMaterial.map = this._texture;

--- a/ReactVR/js/Views/__tests__/BaseMesh-test.js
+++ b/ReactVR/js/Views/__tests__/BaseMesh-test.js
@@ -21,9 +21,19 @@ MockTextureLoader.prototype.load = function(url, onLoad, onProgress, onError) {
 };
 MockTextureLoader.prototype.setCrossOrigin = function() {};
 
+const MockVector2 = function(x, y) {
+  this.x = x;
+  this.y = y;
+};
+MockVector2.prototype.set = function(x, y) {
+  this.x = x;
+  this.y = y;
+};
+
 const MockTexture = function(source) {
   this.map = source;
   this._disposed = false;
+  this.repeat = new MockVector2(1, 1);
 };
 MockTexture.prototype.dispose = function() {
   this._disposed = true;
@@ -51,6 +61,7 @@ jest.mock('three', () => {
     Matrix4: jest.fn(() => ({})),
     Ray: jest.fn(() => ({})),
     Sphere: jest.fn(() => ({})),
+    RepeatWrapping: 1000,
   };
 });
 
@@ -99,6 +110,28 @@ describe('RCTBaseMesh', () => {
         expect(mesh._textureURL).toBe(path);
         expect(manager.isTextureLoading(path)).toBe(false);
         expect(manager.isTextureCached(path)).toBe(true);
+      })
+      .then(() => {
+        done();
+      });
+  });
+
+  it('sets texture repeat mode', done => {
+    const repeatWrappingMock = 1000;
+    const repeatX = 4;
+    const repeatY = 4;
+    const manager = new TextureManager();
+    const mesh = new BaseMesh({}, {TextureManager: manager});
+    const path = 'http://example.net/img.png';
+    mesh.props.texture = {uri: path, repeat: [repeatX, repeatY]};
+    const tex = new MockTexture();
+    TextureLoads[path].onLoad(tex);
+    Promise.resolve()
+      .then(() => {
+        expect(mesh._texture.wrapS).toBe(repeatWrappingMock);
+        expect(mesh._texture.wrapT).toBe(repeatWrappingMock);
+        expect(mesh._texture.repeat.x).toBe(repeatX);
+        expect(mesh._texture.repeat.y).toBe(repeatY);
       })
       .then(() => {
         done();


### PR DESCRIPTION
## Motivation

I want to introduce an option to set texture's mode to `RepeatWrapping`. I added it to BasicMesh class, so all object, which inherits from this class can make use of it. The API is simple, you need to add `repeat` property to `texture` object, which you pass to Mesh component (see below).

I added proper test case. I would like to add proper note to docs, if code is fine for you.

## Test Plan

You can use it in `Plane` component:
```js
<Plane
  texture={{
    ...asset('texture.jpg'),
    repeat: [4, 4],
  }}
/>
```

Here's a result:

<img width="938" alt="screen shot 2017-09-17 at 19 55 20" src="https://user-images.githubusercontent.com/3169629/30523490-8d5284ca-9be2-11e7-9b1b-3b5cd01db791.png">

---
**Side note:** Strange, Flowtype doesn't recognise `repeat` property in `Texture` class, although it's present in this class (see [Texture.js](https://github.com/mrdoob/three.js/blob/12f4ac35caeefa2bda307ee7e2047df11d093427/src/textures/Texture.js#L41) file in three.js repository).