### PR TITLE
Support 12 image stereo cubemap in Prefetch

### DIFF
--- a/ReactVR/js/Views/Prefetch.js
+++ b/ReactVR/js/Views/Prefetch.js
@@ -54,7 +54,7 @@ export default class RCTPrefetch extends RCTBaseView {
 
     if (Array.isArray(uri)) {
       // Cubemap, check proper format
-      if (uri.length !== 6 || !uri[0].uri) {
+      if ((uri.length !== 6 && uri.length !== 12) || !uri[0].uri) {
         console.warn(
           'Prefetch expected cubemap source in format [{uri: http..}, {uri: http..}, ... ]'
         );


### PR DESCRIPTION
Currently `Prefetch` only supports the 6 image mono cubemaps, while `Pano` supports both mono cubemaps and 12 image stereo cubemaps.

Same logic as per Pano component: https://github.com/facebook/react-vr/blob/055cfdfde43d7d110db0ab0bafa8d91c6da02024/ReactVR/js/Views/Pano.js#L290