### PR TITLE
Add Code of Conduct

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,3 @@
+# Code of Conduct
+
+Facebook has adopted a Code of Conduct that we expect project participants to adhere to. Please [read the full text](https://code.facebook.com/pages/876921332402685/open-source-code-of-conduct) so that you can understand what actions will and will not be tolerated.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,6 +2,10 @@
 
 React VR is actively being developed by Oculus and Facebook, and is used to power a growing number of internal and external applications. We've put together this document to help make the public contribution process clearer and answer any questions you may have.
 
+## Code of Conduct
+
+Facebook has adopted a Code of Conduct that we expect project participants to adhere to. Please [read the full text](https://code.facebook.com/pages/876921332402685/open-source-code-of-conduct) so that you can understand what actions will and will not be tolerated.
+
 ## Pull Requests
 
 Our core team will be monitoring for pull requests. New pull requests will automatically run against our continuous integration suite, which should detect the majority of formatting and testing issues. After this, one of our team members will run some Facebook-specific integration tests on it, to make sure it doesn't break any of our applications. Once that has completed, one member of the team will sign off on the changes and merge the pull request. Any API changes might require us to fix internal uses, which could cause some delay. We'll do our best to provide updates and feedback in a timely manner throughout the process.


### PR DESCRIPTION
**what is the change?:**
Adding a document linking to the Facebook Open Source Code of Conduct,
for visibility and to meet Github community standards.

**why make this change?:**
Facebook Open Source provides a Code of Conduct statement for all
projects to follow.

Exposing the COC via a separate markdown file is a standard being
promoted by Github via the Community Profile in order to meet their Open
Source Guide's recommended community standards.

As you can see, adding this file will complete [React VR's Community Profile](https://github.com/facebook/react-vr/community)
checklist and increase the visibility of our COC.

**test plan:**
Viewing it on my branch -
<img width="1332" alt="screen shot 2017-11-21 at 7 51 08 am" src="https://user-images.githubusercontent.com/1114467/33082272-3862795c-ce91-11e7-8916-73d4f8959fba.png">
<img width="1303" alt="screen shot 2017-11-21 at 7 54 19 am" src="https://user-images.githubusercontent.com/1114467/33082273-38815ea8-ce91-11e7-9ca9-adb19dc0bbb5.png">

**issue:**
internal task t23481323