### PR TITLE
Documentation Fix: Error with "array array" in onMove section

### DIFF
--- a/docs/Input.md
+++ b/docs/Input.md
@@ -35,7 +35,7 @@ component. It has the same properties as `onEnter` events.
 
 This event fires as the cursor moves across a View. The position of the
 cursor is passed as the `offset` property of the event: a two-unit array
-array representing the x and y coordinates of the cursor relative to the view.
+representing the x and y coordinates of the cursor relative to the view.
 These values are unitless numbers ranging from 0.0 to 1.0, where `[0, 0]`
 represents the top-left corner of a View, `[0.5, 0.5]` represents the center of
 the view, and `[1.0, 1.0]` represents the bottom-right corner. Using unitless


### PR DESCRIPTION
I believe the word "array" was mistakenly duplicated (unless it is an array of two-unit arrays?? But that doesn't seem to be the case based on the examples e.g. [0, 0] ).

## Motivation (required)
Documentation fix removing duplicate word "array" in docs in onMove section of [input page](https://facebook.github.io/react-vr/docs/input.html)

## Test Plan (required)
N/A - strictly a documentation change; no code change.

signed CLA