### PR TITLE
Updated Image Referencing Instruction

### DIFF
--- a/docs/image.md
+++ b/docs/image.md
@@ -5,8 +5,11 @@ sidebar_label: Image
 ---
 
 A React component for displaying 2D images on a surface. Image sources can be externally-hosted resources, or referenced from your `static_assets` directory and hosted alongside your app.
+For images referenced from your `static_assets` directory, you will need to import `asset` from `react-360`
 
 ```js
+import { asset } from 'react-360';
+
 renderImages() {
   return (
     <View>


### PR DESCRIPTION
Added more detailed instruction on how to reference image from "static_assets"

## Motivation (required)
I was following the documentation's instruction on how to load image in the image section and was not able to reproduce the result due to a missing import that is not explicitly mention.

## What existing problem does the pull request solve?
Clearer instruction for importing static assets

