### PR TITLE
Star link in Footer isn't working [Website] #781 solved may be

### DIFF
--- a/website/core/Footer.js
+++ b/website/core/Footer.js
@@ -50,8 +50,8 @@ class Footer extends React.Component {
               className="github-button"
               href={this.props.config.repoUrl}
               data-icon="octicon-star"
-              data-count-href="/facebook/react-360/stargazers"
-              data-show-count={true}
+              data-count-href={`${this.props.config.repoUrl}/stargazers`}
+              data-show-count="true"
               data-count-aria-label="# stargazers on GitHub"
               aria-label="Star this project on GitHub">
               Star


### PR DESCRIPTION
Description
Is this a Bug or a Feature Request?
A bug. Star link in the footer is not working.

Expected behavior
It should lead to the repository to be starred.

Actual behavior
It is dead.

Reproduction
Open the website
Scroll down to the footer
Try clicking on the 'Star' link
Additional Information
Operating System: [MacOS]
Browser: [Chrome Version 79.0.3945.130]