### PR TITLE
solved the footer star problem

### DIFF
--- a/website/core/Footer.js
+++ b/website/core/Footer.js
@@ -45,7 +45,7 @@ class Footer extends React.Component {
           <div>
             <h5>More</h5>
             <a href={this.props.config.baseUrl + 'blog'}>Blog</a>
-            <a href="https://github.com/facebook/react-360">GitHub</a>
+            <a href={this.props.config.repoUrl} target="_blank" rel="noreferrer noopener">GitHub</a>
             <a
               className="github-button"
               href={this.props.config.repoUrl}

--- a/website/siteConfig.js
+++ b/website/siteConfig.js
@@ -71,9 +71,10 @@ const siteConfig = {
   ogImage: 'img/docusaurus.png',
   twitterImage: 'img/docusaurus.png',
 
-  // You may provide arbitrary config keys to be used as needed by your
-  // template. For example, if you need your repo's URL...
-  //   repoUrl: 'https://github.com/facebook/test-site',
+    // This repoUrl info is used in /core/Footer.js and pages/en/users.js
+    repoUrl: 'https://github.com/facebook/react-360',
+
+
 };
 
 module.exports = siteConfig;


### PR DESCRIPTION
Description
Is this a Bug or a Feature Request?
A bug. Star link in the footer is not working.

Expected behavior
It should lead to the repository to be starred.

Actual behavior
It is dead.

Reproduction
Open the website
Scroll down to the footer
Try clicking on the 'Star' link
Additional Information
Operating System: [MacOS]
Browser: [Chrome Version 79.0.3945.130]